### PR TITLE
Fix naming import module vuelayers

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -24,7 +24,7 @@ export default {
   buildModules: ['@nuxtjs/eslint-module', '@nuxtjs/tailwindcss'],
   modules: [
     '@nuxtjs/axios',
-    '~/modules/vueLayers',
+    '~/modules/vuelayers',
     [
       'nuxt-i18n',
       {


### PR DESCRIPTION
Otherwise nuxt complains not finding `vueLayers `module...